### PR TITLE
Fluent interface in TokenBuilder setters / optional aud claim

### DIFF
--- a/src/TokenBuilder.php
+++ b/src/TokenBuilder.php
@@ -183,7 +183,9 @@ class TokenBuilder extends TokenAbstract
             $this->payload = array_merge($this->payload, ['iss' => $this->getIssuer()]);
             $this->payload = array_merge($this->payload, ['exp' => $this->getExpiration()->getTimestamp()]);
             $this->payload = array_merge($this->payload, ['sub' => $this->getSubject()]);
-            $this->payload = array_merge($this->payload, ['aud' => $this->getAudience()]);
+            if (!empty($this->getAudience())) {
+                $this->payload = array_merge($this->payload, ['aud' => $this->getAudience()]);
+            }
         }
 
         return json_encode($this->payload);

--- a/src/TokenBuilder.php
+++ b/src/TokenBuilder.php
@@ -130,10 +130,13 @@ class TokenBuilder extends TokenAbstract
      * Set the audience of the token
      *
      * @param string $audience
+     *
+     * @return TokenBuilder
      */
     public function setAudience(string $audience)
     {
         $this->audience = $audience;
+        return $this;
     }
 
     /**
@@ -150,10 +153,13 @@ class TokenBuilder extends TokenAbstract
      * Set the subject of the token
      *
      * @param string $subject
+     *
+     * @return TokenBuilder
      */
     public function setSubject(string $subject)
     {
         $this->subject = $subject;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Be consistent about fluent interface in TokenBuilder setters.
The `aud` (audience) claim should be optional and it should not get added to payload if it was not set.
Thanks, Philip