### PR TITLE
Removed none from the validate algorithm method.

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -89,12 +89,11 @@ class Validate
 
     /**
      * Check the alg claim is in the list of valid algorithms. These are the
-     * valid digital signatures, MAC algorithms or "none" as
-     * defined in RFC 7518.
+     * valid digital signatures, MAC algorithms as defined in RFC 7518.
      */
     public function algorithm(string $algorithm, array $additional): bool
     {
-        $base = ["none", "HS256"];
+        $base = ["HS256"];
 
         return in_array($algorithm, array_merge($base, $additional));
     }

--- a/tests/ValidateTest.php
+++ b/tests/ValidateTest.php
@@ -169,15 +169,6 @@ class ValidateTest extends TestCase
         $this->assertTrue($validate->algorithm($algorithm, []));
     }
 
-    public function testValidateAlgorithmNone()
-    {
-        $validate = new Validate();
-
-        $algorithm = "none";
-
-        $this->assertTrue($validate->algorithm($algorithm, []));
-    }
-
     public function testValidateAlgorithmFail()
     {
         $validate = new Validate();


### PR DESCRIPTION
Validating the algorithm is potential security hole so it has been removed as a default.