### PR TITLE
Add more helpful error message to secret validation error

### DIFF
--- a/src/Build.php
+++ b/src/Build.php
@@ -118,7 +118,7 @@ class Build
     public function setSecret(string $secret): Build
     {
         if (!$this->secretValidator->validate($secret)) {
-            throw new BuildException('Invalid secret.', 9);
+            throw new BuildException('Invalid secret. See https://github.com/RobDWaller/ReallySimpleJWT#signature-secret for secret requirements', 9);
         }
 
         $this->secret = $secret;


### PR DESCRIPTION
This might prevent issues like this by providing link to docs in a error message.

As I commented in https://github.com/RobDWaller/ReallySimpleJWT/issues/54

Might be worth doing for more error messages as well